### PR TITLE
Add max extraction processes setting

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -33,3 +33,8 @@ define('TOOL_METADATA_RESOURCE_TYPE_FILE', 'file');
  * TOOL_METADATA_RESOURCE_TYPE_URL - Metadata for a mod_url instance.
  */
 define('TOOL_METADATA_RESOURCE_TYPE_URL', 'url');
+
+/**
+ * TOOL_METADATA_MAX_PROCESSES_DEFAULT - Default number of maximum asynchronous extraction tasks to queue at once.
+ */
+define('TOOL_METADATA_MAX_PROCESSES_DEFAULT', 1000);

--- a/lang/en/tool_metadata.php
+++ b/lang/en/tool_metadata.php
@@ -45,7 +45,11 @@ $string['status:extractionnotsupported'] = 'Metadata extraction not supported fo
 $string['status:nometadata'] = 'Could not extract metadata for resource id: {$a->resourceid}, type: {$a->type}.';
 
 // Settings strings.
-$string['settings:extractor:manage'] = 'Manage metadata extractor plugins';
+$string['settings:manageextraction'] = 'Manage extraction';
+$string['settings:manageextractors'] = 'Manage metadata extractor subplugins';
+$string['settings:manage'] = 'Metadata settings';
+$string['settings:maxextractionprocesses'] = 'Maximum extraction processes';
+$string['settings:maxextractionprocesses_help'] = 'Maximum extraction processes for each resource type which can be added to queue for asynchronous extraction.';
 $string['settings:supportedfileextensions'] = 'Supported file extensions';
 
 // Subplugin strings.

--- a/settings.php
+++ b/settings.php
@@ -24,12 +24,28 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG, $ADMIN;
+require_once($CFG->dirroot . '/admin/tool/metadata/constants.php');
+
 // Add the metadata plugin type to modules and a page to manage extractor subplugins.
 $ADMIN->add('modules', new admin_category('metadata',
     get_string('pluginname', 'tool_metadata')));
-$temp = new admin_settingpage('managemetadataextractors',
-    get_string('settings:extractor:manage', 'tool_metadata'));
+
+$temp = new admin_settingpage('metadatasettings',
+    get_string('settings:manage', 'tool_metadata'));
+
+// Setting for managing subplugins.
+$temp->add(new admin_setting_heading('managemetadataextractors',
+    get_string('settings:manageextractors', 'tool_metadata'), ''));
 $temp->add(new \tool_metadata\admin_setting_manage_metadataextractor_plugins());
+
+// Settings for managing extraction process.
+$temp->add(new admin_setting_heading('managemetadataextractionfilters',
+    get_string('settings:manageextraction', 'tool_metadata'), ''));
+$temp->add(new admin_setting_configtext('tool_metadata/max_extraction_processes',
+    get_string('settings:maxextractionprocesses', 'tool_metadata'),
+    get_string('settings:maxextractionprocesses_help', 'tool_metadata'),
+    TOOL_METADATA_MAX_PROCESSES_DEFAULT, PARAM_INT));
 $ADMIN->add('metadata', $temp);
 
 // Load the settings.php scripts for each metadataextractor submodule.

--- a/tests/process_file_extractions_task_test.php
+++ b/tests/process_file_extractions_task_test.php
@@ -139,7 +139,8 @@ class process_file_extractions_task_testcase extends advanced_testcase {
         // for test.
         $DB->delete_records('files');
 
-        $filecount = \tool_metadata\task\process_file_extractions_task::MAX_PROCESSES + 1;
+        $maxextractions = get_config('tool_metadata', 'max_extraction_processes');
+        $filecount = $maxextractions + 1;
         $files = [];
 
         $fs = get_file_storage();
@@ -166,12 +167,12 @@ class process_file_extractions_task_testcase extends advanced_testcase {
         $actual = $task->get_extractions_to_process(['mock' => $extractor, 'mocktwo' => $extractortwo]);
 
         // Expect 2 times the max processes as we are using 2 extractors.
-        $expected = 2 * \tool_metadata\task\process_file_extractions_task::MAX_PROCESSES;
+        $expected = 2 * $maxextractions;
         $this->assertCount($expected, $actual);
 
         $actual = $task->get_extractions_to_process(['mock' => $extractor, 'mocktwo' => $extractortwo]);
         // Expect 2 times the amount over max processes as we are using 2 extractors.
-        $expected = 2 * ($filecount - \tool_metadata\task\process_file_extractions_task::MAX_PROCESSES);
+        $expected = 2 * ($filecount - $maxextractions);
         $this->assertCount($expected, $actual);
     }
 

--- a/tests/process_url_extractions_task_test.php
+++ b/tests/process_url_extractions_task_test.php
@@ -129,7 +129,8 @@ class process_url_extractions_task_testcase extends advanced_testcase {
         // for test.
         $DB->delete_records('url');
 
-        $urlcount = \tool_metadata\task\process_file_extractions_task::MAX_PROCESSES + 1;
+        $maxextractions = get_config('tool_metadata', 'max_extraction_processes');
+        $urlcount = $maxextractions + 1;
         $urls = [];
 
         $course = $this->getDataGenerator()->create_course();
@@ -146,12 +147,12 @@ class process_url_extractions_task_testcase extends advanced_testcase {
         $actual = $task->get_extractions_to_process(['mock' => $extractor, 'mocktwo' => $extractortwo]);
 
         // Expect 2 times the max processes as we are using 2 extractors.
-        $expected = 2 * \tool_metadata\task\process_file_extractions_task::MAX_PROCESSES;
+        $expected = 2 * $maxextractions;
         $this->assertCount($expected, $actual);
 
         $actual = $task->get_extractions_to_process(['mock' => $extractor, 'mocktwo' => $extractortwo]);
         // Expect 2 times the amount over max processes as we are using 2 extractors.
-        $expected = 2 * ($urlcount - \tool_metadata\task\process_file_extractions_task::MAX_PROCESSES);
+        $expected = 2 * ($urlcount - $maxextractions);
         $this->assertCount($expected, $actual);
     }
 


### PR DESCRIPTION
Add a setting to allow admin to determine how many asynchronous
extraction tasks can be queued at a time for each resource type.

Resolves #8