### PR TITLE
bug: failing metadata extraction continues indefinitely

### DIFF
--- a/classes/task/metadata_extraction_task.php
+++ b/classes/task/metadata_extraction_task.php
@@ -97,6 +97,16 @@ class metadata_extraction_task extends adhoc_task {
                 if (debugging('', DEBUG_DEVELOPER)) {
                     mtrace(format_backtrace($ex->getTrace(), true));
                 }
+
+                if ($this->get_fail_delay() >= get_config('tool_metadata', 'faildelay_threshold')) {
+                    $extraction->set('status', extraction::STATUS_NOT_SUPPORTED);
+                    $extraction->set('reason', get_string('status:extractionnotsupported', 'tool_metadata',
+                        [ 'resourceid' => $data->resourceid, 'type' => $data->type, 'plugin' => $data->plugin ]));
+                } else {
+                    // Update extraction status and rethrow exception to trigger failed task.
+                    $extraction->save();
+                    throw $ex;
+                }
             }
         }
         $extraction->save();

--- a/classes/task/metadata_extraction_task.php
+++ b/classes/task/metadata_extraction_task.php
@@ -98,7 +98,12 @@ class metadata_extraction_task extends adhoc_task {
                     mtrace(format_backtrace($ex->getTrace(), true));
                 }
 
-                if ($this->get_fail_delay() >= get_config('tool_metadata', 'faildelay_threshold')) {
+                $faildelaythreshold = get_config('tool_metadata', 'faildelay_threshold');
+                if (empty($faildelaythreshold)) {
+                    $faildelaythreshold = TOOL_METADATA_FAIL_DELAY_THRESHOLD_DEFAULT;
+                }
+
+                if ($this->get_fail_delay() >= $faildelaythreshold) {
                     $extraction->set('status', extraction::STATUS_NOT_SUPPORTED);
                     $extraction->set('reason', get_string('status:extractionnotsupported', 'tool_metadata',
                         [ 'resourceid' => $data->resourceid, 'type' => $data->type, 'plugin' => $data->plugin ]));

--- a/constants.php
+++ b/constants.php
@@ -38,3 +38,8 @@ define('TOOL_METADATA_RESOURCE_TYPE_URL', 'url');
  * TOOL_METADATA_MAX_PROCESSES_DEFAULT - Default number of maximum asynchronous extraction tasks to queue at once.
  */
 define('TOOL_METADATA_MAX_PROCESSES_DEFAULT', 1000);
+
+/**
+ * TOOL_METADATA_FAIL_DELAY_DEFAULT - Default fail delay, over which, metadata extraction will no longer be attempted.
+ */
+define('TOOL_METADATA_FAIL_DELAY_THRESHOLD_DEFAULT', 86400);

--- a/lang/en/tool_metadata.php
+++ b/lang/en/tool_metadata.php
@@ -62,6 +62,9 @@ $string['settings:extractionfilters_help'] = "<p>A JSON string containing an arr
     \"value\": \"badges\" // The field value to exclude from extractions
 }</code></pre>
 ";
+$string['settings:faildelaythreshold'] = 'Fail delay threshold';
+$string['settings:faildelaythreshold_help'] = "<p>The maximum fail delay for asynchronous metadata extraction, if an extraction task continues to fail, once the faildelay value for the task reaches this threshold, it is assumed that extraction of metadata for the associated resource is not supported.</p>
+<p>Extraction will no longer be attempted for the resource in question and the extraction status will be updated to reflect that extraction of metadata for the resource is not supported.</p>";
 $string['settings:supportedfileextensions'] = 'Supported file extensions';
 
 // Subplugin strings.

--- a/settings.php
+++ b/settings.php
@@ -52,6 +52,10 @@ $temp->add(new admin_setting_configtext('tool_metadata/max_extraction_processes'
 $temp->add(new admin_setting_configtextarea_json('tool_metadata/extraction_filters',
     get_string('settings:extractionfilters', 'tool_metadata'),
     get_string('settings:extractionfilters_help', 'tool_metadata'), '[ ]', PARAM_RAW));
+$temp->add(new admin_setting_configtext('tool_metadata/faildelay_threshold',
+    get_string('settings:faildelaythreshold', 'tool_metadata'),
+    get_string('settings:faildelaythreshold_help', 'tool_metadata'),
+    TOOL_METADATA_FAIL_DELAY_THRESHOLD_DEFAULT, PARAM_INT));
 $ADMIN->add('metadata', $temp);
 
 // Load the settings.php scripts for each metadataextractor submodule.

--- a/tests/mock_metadataextractor_extractor.php
+++ b/tests/mock_metadataextractor_extractor.php
@@ -23,6 +23,8 @@
  */
 namespace metadataextractor_mock;
 
+use tool_metadata\extraction_exception;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -53,12 +55,17 @@ class extractor extends \tool_metadata\extractor {
      * @param \stored_file $file the file to extract metadata from.
      *
      * @return \metadataextractor_mock\metadata a mock of metadata instance.
+     * @throws \tool_metadata\extraction_exception
      */
     public function extract_file_metadata($file) {
         $rawmetadata = [];
         // Cheat by mocking metadata using the file's own contents.
         $rawmetadata['dc:creator'] = $file->get_author();
         $rawmetadata['dc:title'] = $file->get_filename();
+
+        if ($file->get_license() == 'triggerfail') {
+            throw new extraction_exception('error:extractionfailed');
+        }
 
         $metadata = new metadata(0, $file->get_contenthash(), $rawmetadata);
 


### PR DESCRIPTION
This patch fixes resolves #12 by adding a fail_delay_threshold
setting, which can be set to prevent metadata extraction for a
resource continuing to be attempted past a set fail delay limit.