### PR TITLE
#59: Add \Throwable to catch

### DIFF
--- a/classes/task/metadata_extraction_task.php
+++ b/classes/task/metadata_extraction_task.php
@@ -131,7 +131,7 @@ class metadata_extraction_task extends adhoc_task {
                     $extraction->set('reason', get_string('status:nometadata', 'tool_metadata',
                         ['resourceid' => $data->resourceid, 'type' => $data->type]));
                 }
-            } catch (\moodle_exception $ex) {
+            } catch (\Throwable $ex) {
                 $extraction->set('status', extraction::STATUS_ERROR);
                 $extraction->set('reason', $ex->getMessage());
                 mtrace($ex->getMessage());


### PR DESCRIPTION
## Problem: 
When a adhoc task is listed with a `resourceid` of a file which does not exist on the filesystem. The task will be stuck for eternity. This is because the exception thrown in line 269 of classes/helper.php: call to GuzzleHttp\Psr7\Stream->__construct() does not throw a `moodle_exception`.

## Testing:

1. On a vanilla site 
```
git clone -b add-throwable-to-catch-in-metadata-extraction-task git@github.com:catalyst/moodle-tool_metadata.git admin/tool/metadata
cd admin/tool/metadata && git submodule update --init --recursive
```
2. Install and open admin/settings.php?section=metadatasettings
3. Enable tika **[1]** and readable
4. Open tika **[1]** settings admin/settings.php?section=metadataextractortika
5. Configure tika **[1]**
6. Create a small test course admin/tool/generator/maketestcourse.php
7. The last step should have created a `smallfile0.dat` file for you, we're going to delete this from the filesystem open the site's database and execute the following command:
```
moodle=# SELECT id, filename, contenthash FROM mdl_files WHERE filename = 'smallfile0.dat';
 id |    filename    |               contenthash                
----+----------------+------------------------------------------
 10 | smallfile0.dat | 6db51ad4029f5077e1af277f20a55a652d02a111
(1 row)
```
8. With previous data available to us we need to delete the file from the file system for this ran successfully:
```
rm /var/lib/sitedata/filedir/6d/b5/6db51ad4029f5077e1af277f20a55a652d02a111
```
9. Open the site's database again and execute the following commands:
```
BEGIN;
INSERT INTO mdl_task_adhoc (classname, nextruntime, faildelay, customdata, blocking, timecreated) VALUES ('\tool_metadata\task\metadata_extraction_task', 0, 86400, '{"resourceid":10,"type":"file","plugin":"tika"}', 0, 0);
INSERT INTO mdl_task_adhoc (classname, nextruntime, faildelay, customdata, blocking, timecreated) VALUES ('\tool_metadata\task\metadata_extraction_task', 0, 86400, '{"resourceid":10,"type":"file","plugin":"readable"}', 0, 0);
COMMIT;
```
10. Double check you've used the same resourceid in step 9 as the id in step 7
11. On the server execute the following command: 
```
php admin/cli/adhoc_task.php --execute
```
12. Finally check that the mdl_task_adhoc table is empty since the tasks got deleted having a faildelay over the default of 200.


---
**[1]: Set up tika service**  

Tika needs a service. If you're using docker with docker-compose add the following to your services: 
```
  tika:
    container_name: tika
    image: apache/tika:latest
    restart: unless-stopped
```
Then do `docker-compose up -d`. After that's completed you can setup tika like this: 
![image](https://user-images.githubusercontent.com/19667071/181145590-0064e865-4334-4d89-a0a7-cc176249062f.png)
